### PR TITLE
tread lightly on backslash mappings

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -50,7 +50,7 @@ xnoremap <silent> <Plug>Commentary     :<C-U>call <SID>go(visualmode())<CR>
 nnoremap <silent> <Plug>Commentary     :<C-U>set opfunc=<SID>go<CR>g@
 nnoremap <silent> <Plug>CommentaryLine :<C-U>call <SID>go(v:count1)<CR>
 
-if maparg('\\') ==# ''
+if maparg('\\') ==# '' && maparg('\') ==# ''
   xmap \\  <Plug>Commentary
   nmap \\  <Plug>Commentary
   nmap \\\ <Plug>CommentaryLine


### PR DESCRIPTION
Commentary's awesome. 

I use backslash to open the nerdtree. I don't want vim to pause for a moment after I hit the key, so I avoid having other mappings beginning with backslash. I figured other people might use backslash for other things.
