### PR TITLE
Change nmap \\\ to nmap \\\\ to fix the mapping and get rid of spurious startup message.

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -68,7 +68,7 @@ endif
 if maparg('\\','n') ==# '' && maparg('\','n') ==# ''
   xmap \\  <Plug>Commentary
   nmap \\  <Plug>Commentary
-  nmap \\\ <Plug>CommentaryLine
+  nmap \\\\ <Plug>CommentaryLine
   nmap \\u <Plug>CommentaryUndo
 endif
 

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -66,10 +66,19 @@ if !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
 endif
 
 if maparg('\\','n') ==# '' && maparg('\','n') ==# ''
+
+  " If B is missing from cpoptions, Vim will treat backslashes in the
+  " following mappings as escape sequences, when we actually want these to
+  " be literal backslashes. So temporarily set B in cpoptions.
+  let save_cpo = &cpoptions
+  set cpoptions+=B
+
   xmap \\  <Plug>Commentary
   nmap \\  <Plug>Commentary
-  nmap \\\\ <Plug>CommentaryLine
+  nmap \\\ <Plug>CommentaryLine
   nmap \\u <Plug>CommentaryUndo
+
+  let &cpoptions = save_cpo
 endif
 
 " vim:set et sw=2:


### PR DESCRIPTION
In Vim 7.3.754, the `nmap \\\ <Plug>CommentaryLine` line causes the following message to be displayed every time I start vim:

```
n  \             <Plug>Commentary
```

and the `\\` mapping does not get defined.

Changing it to `nmap \\\\ <Plug>CommentaryLine` seems to correct this problem.
