### PR TITLE
Add flag g:commentary_map_backslash

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -65,7 +65,7 @@ if !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
   nmap gcu <Plug>CommentaryUndo
 endif
 
-if maparg('\\','n') ==# '' && maparg('\','n') ==# ''
+if maparg('\\','n') ==# '' && maparg('\','n') ==# '' && (!exists('g:commentary_map_backslash') || g:commentary_map_backslash != 0)
   xmap \\  <Plug>Commentary
   nmap \\  <Plug>Commentary
   nmap \\\ <Plug>CommentaryLine


### PR DESCRIPTION
- If `g:commentary_map_backslash == 0`, don't map the old
  backslash-prefixed normal commands

The `\\`, `\\\`, and `\\u` maps bother me, as someone who uses `\` as his `mapleader`. They don't get mapped if maps already exist for those keys, but I don't want them there at all, ever. This adds a flag to allow for that. Default behaviour is unchanged.
