### PR TITLE
Let Commentary be used as a command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,9 @@
 Comment stuff out.  Use `gcc` to comment out a line (takes a count),
 `gc` to comment out the target of a motion (for example, `gcap` to
 comment out a paragraph), `gc` in visual mode to comment out the selection,
-and `gc` in operator pending mode to target a comment.  That's it.
+and `gc` in operator pending mode to target a comment.  You can also use
+it as a command, either with a range like `:7,17Commentary`, or as part of a
+`:global` invocation like with `:g/TODO/Commentary`. That's it.
 
 I wrote this because 5 years after Vim added support for mapping an
 operator, I still couldn't find a commenting plugin that leveraged that

--- a/doc/commentary.txt
+++ b/doc/commentary.txt
@@ -26,6 +26,9 @@ gc                      Text object for a comment (operator pending mode
 gcgc                    Uncomment the current and adjacent commented lines.
 gcu
 
+                                                *:Commentary*
+:[range]Commentary      Comment or uncomment [range] lines
+
 The |User| CommentaryPost autocommand fires after a successful operation and
 can be used for advanced customization.
 

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -79,6 +79,7 @@ nnoremap <silent> <Plug>CommentaryLine :<C-U>set opfunc=<SID>go<Bar>exe 'norm! '
 onoremap <silent> <Plug>Commentary        :<C-U>call <SID>textobject(0)<CR>
 nnoremap <silent> <Plug>ChangeCommentary c:<C-U>call <SID>textobject(1)<CR>
 nmap <silent> <Plug>CommentaryUndo <Plug>Commentary<Plug>Commentary
+command! -range -bar Commentary call s:go(<line1>,<line2>)
 
 if 1 || !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
   xmap gc  <Plug>Commentary


### PR DESCRIPTION
This lets us do things like `:g/TODO/Commentary` or `:.,'aCommentary`, which was something I wanted to do today but couldn't.
