### PR TITLE
Delete unnecessary \\ mapping

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -90,11 +90,4 @@ if 1 || !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
   nmap gcu <Plug>Commentary<Plug>Commentary
 endif
 
-if maparg('\\','n') ==# '' && maparg('\','n') ==# '' && get(g:, 'commentary_map_backslash', 1)
-  xmap \\  <Plug>Commentary:echomsg '\\ is deprecated. Use gc'<CR>
-  nmap \\  :echomsg '\\ is deprecated. Use gc'<CR><Plug>Commentary
-  nmap \\\ <Plug>CommentaryLine:echomsg '\\ is deprecated. Use gc'<CR>
-  nmap \\u <Plug>CommentaryUndo:echomsg '\\ is deprecated. Use gc'<CR>
-endif
-
 " vim:set et sw=2:


### PR DESCRIPTION
Mapping \\ to a warning message can be annoying to the people who use \ as the leader key. People can simply learn the new mapping from the documentation.
