### PR TITLE
Make whitespace around comment be optional based on commentstring

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -9,9 +9,7 @@ endif
 let g:loaded_commentary = 1
 
 function! s:surroundings() abort
-  return split(substitute(substitute(
-        \ get(b:, 'commentary_format', &commentstring)
-        \ ,'\S\zs%s',' %s','') ,'%s\ze\S', '%s ', ''), '%s', 1)
+  return split(get(b:, 'commentary_format', &commentstring), '%s', 1)
 endfunction
 
 function! s:go(type,...) abort


### PR DESCRIPTION
This would resolve #33 

Space around comment should be based on commentstring such that with `commentstring=//%s` you get:

``` cpp
//var example = "hi";
//var anotherExample = "hello";
```

But with `commentstring=//\ %s` you get

``` cpp
// var example = "hi";
// var anotherExample = "hello";
```

Or `commentstring=<!--%s-->` you get

``` html
<!--example-->
```

And with `commentstring=<!--\ \ \ %s\ \ \ -->` you get

``` html
<!--   example   -->
```
