### PR TITLE
Remove deprecated messages

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -89,11 +89,4 @@ if !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
   nmap gcu <Plug>Commentary<Plug>Commentary
 endif
 
-if maparg('\\','n') ==# '' && maparg('\','n') ==# '' && get(g:, 'commentary_map_backslash', 1)
-  xmap \\  <Plug>Commentary:echomsg '\\ is deprecated. Use gc'<CR>
-  nmap \\  :echomsg '\\ is deprecated. Use gc'<CR><Plug>Commentary
-  nmap \\\ <Plug>CommentaryLine:echomsg '\\ is deprecated. Use gc'<CR>
-  nmap \\u <Plug>CommentaryUndo:echomsg '\\ is deprecated. Use gc'<CR>
-endif
-
 " vim:set et sw=2:


### PR DESCRIPTION
When I press my leader key ( \ ) for more than a couple of millis, it shows these annoying messages.
Besides, it's already very clear in the documentation that one should use `gc` to comment out the target of a motion.