### PR TITLE
Use setlocal in the filetype example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ Once help tags have been generated, you can view the manual with
 
 Relax!  You just have to adjust `'commentstring'`:
 
-    autocmd FileType apache set commentstring=#\ %s
+    autocmd FileType apache setlocal commentstring=#\ %s
 
 ## Self-Promotion
 


### PR DESCRIPTION
Using local is problematic with multiple buffers/windows, e.g.:

- You have the auto-command configured for cmake files, where the
  comment string is set to '#'
- You split your main window into 2 side-by-side ones
- In the left window you open a C++ file
- In the right window you open a cmake file
- voila, the wrong comment string is then used when commenting out stuff
  with commentary commands in the left window