### PR TITLE
Add AppStream metadata.

### DIFF
--- a/appstream/vim-commentary.metainfo.xml
+++ b/appstream/vim-commentary.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+<id>vim-commentary</id>
+<extends>gvim.desktop</extends>
+<name>commentary.vim</name>
+<summary>Comment stuff out; takes a motion as a target</summary>
+<url type="homepage">http://www.vim.org/scripts/script.php?script_id=3695</url>
+<metadata_license>CC0-1.0</metadata_license>
+<project_license>VIM</project_license>
+<updatecontact>v.ondruch@gmail.com</updatecontact>
+</component>


### PR DESCRIPTION
I am going to package commentary.vim for Fedora and since I'd like to provide best user experience, i.e. to have this plugin shown in gnome-software [1], it be cool if you can include these metadata in your upstream repository.

[1] https://blogs.gnome.org/hughsie/2014/06/11/application-addons-in-gnome-software/
