### PR TITLE
Fixed error when commentstring is not defined

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -22,6 +22,11 @@ function! s:strip_white_space(l,r,line) abort
 endfunction
 
 function! s:go(type,...) abort
+  if &commentstring == ''
+    echohl WarningMsg | echom 'commentary: commentstring not set' | echohl NONE
+    return
+  endif
+
   if a:0
     let [lnum1, lnum2] = [a:type, a:1]
   else


### PR DESCRIPTION
As discussed in [issue #43][1], commentary will produce a messy error
when commentstring is not defined. This fixes that issue by printing a
warning message instead.

    Error detected while processing function <SNR>40_go:
    line    7:
    E688: More targets than List items

becomes

    commentary: commentstring not set

[1]: https://github.com/tpope/vim-commentary/issues/43