### PR TITLE
Fix uncommenting with irregular white spaces.

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -15,8 +15,11 @@ endfunction
 
 function! s:strip_white_space(l,r,line) abort
   let [l, r] = [a:l, a:r]
-  if stridx(a:line,l) == -1 && stridx(a:line,l[0:-2]) == 0 && a:line[strlen(a:line)-strlen(r[1:]):-1] == r[1:]
-    return [l[0:-2], r[1:]]
+  if l[-1:] == ' ' && stridx(a:line,l) == -1 && stridx(a:line,l[0:-2]) == 0
+    let l = l[:-2]
+  endif
+  if r[0] == ' ' && a:line[-strlen(r):] != r && a:line[1-strlen(r):] == r[1:]
+    let r = r[1:]
   endif
   return [l, r]
 endfunction
@@ -28,11 +31,11 @@ function! s:go(type,...) abort
     let [lnum1, lnum2] = [line("'["), line("']")]
   endif
 
-  let [l_, r_] = s:surroundings()
+  let [l, r] = s:surroundings()
   let uncomment = 2
   for lnum in range(lnum1,lnum2)
     let line = matchstr(getline(lnum),'\S.*\s\@<!')
-    let [l, r] = s:strip_white_space(l_,r_,line)
+    let [l, r] = s:strip_white_space(l,r,line)
     if line != '' && (stridx(line,l) || line[strlen(line)-strlen(r) : -1] != r)
       let uncomment = 0
     endif
@@ -62,14 +65,13 @@ function! s:go(type,...) abort
 endfunction
 
 function! s:textobject(inner) abort
-  let [l_, r_] = s:surroundings()
-  let [l, r] = [l_, r_]
+  let [l, r] = s:surroundings()
   let lnums = [line('.')+1, line('.')-2]
   for [index, dir, bound, line] in [[0, -1, 1, ''], [1, 1, line('$'), '']]
     while lnums[index] != bound && line ==# '' || !(stridx(line,l) || line[strlen(line)-strlen(r) : -1] != r)
       let lnums[index] += dir
       let line = matchstr(getline(lnums[index]+dir),'\S.*\s\@<!')
-      let [l, r] = s:strip_white_space(l_,r_,line)
+      let [l, r] = s:strip_white_space(l,r,line)
     endwhile
   endfor
   while (a:inner || lnums[1] != line('$')) && empty(getline(lnums[0]))


### PR DESCRIPTION
Allow stripping white spaces on the left and right independently.
Also, make sure the stripping is not reverted by subsequent lines
which do have white spaces.

The following cases were broken and is now fixed:

Before this change:
```
1. ^//foo$    -> ^oo$
   ^// bar$      ^bar$
2. ^/*foo */$ -> ^foo $
3. ^/* foo*/$ -> ^/* /1* foo*/ */$
```

After this change:
```
1. ^//foo$    -> ^foo$
   ^// bar$      ^ bar$
2. ^/*foo */$ -> ^foo$
3. ^/* foo*/$ -> ^foo$
```