### PR TITLE
Add a string that marks inserted comments

### DIFF
--- a/doc/commentary.txt
+++ b/doc/commentary.txt
@@ -29,6 +29,22 @@ gcu
                                                 *:Commentary*
 :[range]Commentary      Comment or uncomment [range] lines
 
+
+                                                *g:commentary_marker*
+g:commentary_marker     A string that marks comments inserted by commentary.
+                        This marker is inserted immediately after the comment
+                        string. Useful if commentary is only used to disable
+                        code (rather than inserting explanatory comments).
+                        
+                        For example, >
+                            let g:commentary_marker = '~'
+<                        will comment >
+                            f();
+<                        into >
+                            //~ f();
+<
+                        Use |b:commentary_marker| for a buffer-local override.
+
 The |User| CommentaryPost autocommand fires after a successful operation and
 can be used for advanced customization.
 

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -9,8 +9,11 @@ endif
 let g:loaded_commentary = 1
 
 function! s:surroundings() abort
-  return split(get(b:, 'commentary_format', substitute(substitute(substitute(
-        \ &commentstring, '^$', '%s', ''), '\S\zs%s',' %s', '') ,'%s\ze\S', '%s ', '')), '%s', 1)
+  " Get commentstring with %s and whitespace padding.
+  let cms = substitute(substitute(substitute(
+        \ &commentstring, '^$', '%s', ''), '\S\zs%s',' %s', '') ,'%s\ze\S', '%s ', '')
+  let fmt = get(b:, 'commentary_format', cms)
+  return split(fmt, '%s', 1)
 endfunction
 
 function! s:strip_white_space(l,r,line) abort

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -8,10 +8,17 @@ if exists("g:loaded_commentary") || v:version < 703
 endif
 let g:loaded_commentary = 1
 
+if !exists("g:commentary_marker")
+  let g:commentary_marker = ''
+endif 
+
 function! s:surroundings() abort
   " Get commentstring with %s and whitespace padding.
   let cms = substitute(substitute(substitute(
         \ &commentstring, '^$', '%s', ''), '\S\zs%s',' %s', '') ,'%s\ze\S', '%s ', '')
+  " Postfix comment leader with marker to make auto commented code easier to find.
+  let marker = get(b:, 'commentary_marker', g:commentary_marker)
+  let cms = substitute(cms, '\S\zs\s*%s', marker ..'&','')
   let fmt = get(b:, 'commentary_format', cms)
   return split(fmt, '%s', 1)
 endfunction


### PR DESCRIPTION
This marker is inserted immediately after the comment string. Useful if
commentary is only used to disable code (rather than inserting
explanatory comments).

For example,

      let g:commentary_marker = '~'

will comment

      f();

into

      //~ f();

I find this helps my temporarily disabled code stand out from normal comments.

This also modifies commentary's uncommenting behavior to only remove these blocks. I'm not sure that's a good thing. I don't expect you to take this PR as is, but more a question of whether something like this seems like a good inclusion.