### PR TITLE
do not remove too many chars on uncommenting

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -32,10 +32,12 @@ function! s:go(type,...) abort
   endif
 
   let [l, r] = s:surroundings()
+  let l1 = l
   let uncomment = 2
   for lnum in range(lnum1,lnum2)
     let line = matchstr(getline(lnum),'\S.*\s\@<!')
     let [l, r] = s:strip_white_space(l,r,line)
+    let l1 = strlen(l) < strlen(l1) ? l : l1
     if line != '' && (stridx(line,l) || line[strlen(line)-strlen(r) : -1] != r)
       let uncomment = 0
     endif
@@ -49,7 +51,7 @@ function! s:go(type,...) abort
             \'\=substitute(submatch(0)+1-uncomment,"^0$\\|^-\\d*$","","")','g')
     endif
     if uncomment
-      let line = substitute(line,'\S.*\s\@<!','\=submatch(0)[strlen(l):-strlen(r)-1]','')
+      let line = substitute(line,'\S.*\s\@<!','\=submatch(0)[strlen(l1):-strlen(r)-1]','')
     else
       let line = substitute(line,'^\%('.matchstr(getline(lnum1),'^\s*').'\|\s*\)\zs.*\S\@<=','\=l.submatch(0).r','')
     endif


### PR DESCRIPTION
If the text is not consistently commented like this:

using gcc will remove the leading - on the first line.

That is, because in the first for loop, the l will be set to not include
the leading slash, however after the first iteration, it will be
overwritten and contain '# ' (e.g. 2 chars). Then on uncommenting,
the first two characters will be unconditionally removed.

Fix this, by remembering the shortest match to remove.

references tpope/vim-commentary#92