### PR TITLE
Insert comment characters into beginning of line

### DIFF
--- a/doc/commentary.txt
+++ b/doc/commentary.txt
@@ -6,6 +6,9 @@ License: Same terms as Vim itself (see |license|)
 Comment stuff out.  Then uncomment it later.  Relies on 'commentstring' to be
 correctly set, or uses b:commentary_format if it is set.
 
+Assign b:commentary_startofline to insert comment characters at column 1
+regardless of indentation.
+
                                                 *gc*
 gc{motion}              Comment or uncomment lines that {motion} moves over.
 

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -44,6 +44,12 @@ function! s:go(...) abort
     endif
   endfor
 
+  if get(b:, 'commentary_startofline')
+    let indent = '^'
+  else
+    let indent = '^\s*'
+  endif
+
   for lnum in range(lnum1,lnum2)
     let line = getline(lnum)
     if strlen(r) > 2 && l.r !~# '\\'
@@ -54,7 +60,7 @@ function! s:go(...) abort
     if uncomment
       let line = substitute(line,'\S.*\s\@<!','\=submatch(0)[strlen(l):-strlen(r)-1]','')
     else
-      let line = substitute(line,'^\%('.matchstr(getline(lnum1),'^\s*').'\|\s*\)\zs.*\S\@<=','\=l.submatch(0).r','')
+      let line = substitute(line,'^\%('.matchstr(getline(lnum1),indent).'\|\s*\)\zs.*\S\@<=','\=l.submatch(0).r','')
     endif
     call setline(lnum,line)
   endfor


### PR DESCRIPTION
Fix issue #112 

Assign b:commentary_startofline to insert comment characters at column 1
regardless of indentation.
