### PR TITLE
Added an option to disable the default keymaps

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -103,7 +103,11 @@ onoremap <silent> <Plug>Commentary        :<C-U>call <SID>textobject(get(v:, 'op
 nnoremap <silent> <Plug>ChangeCommentary c:<C-U>call <SID>textobject(1)<CR>
 nmap <silent> <Plug>CommentaryUndo :echoerr "Change your <Plug>CommentaryUndo map to <Plug>Commentary<Plug>Commentary"<CR>
 
-if !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
+
+if !exists('g:commentary_bind_keys')
+  let g:commentary_bind_keys = 1
+endif
+if g:commentary_bind_keys && (!hasmapto('<Plug>Commentary') || maparg('gc','n') ==# '')
   xmap gc  <Plug>Commentary
   nmap gc  <Plug>Commentary
   omap gc  <Plug>Commentary


### PR DESCRIPTION
I do not want to use <kbd>g</kbd> <kbd>c</kbd> to comment, so I added an option to disable the default keymaps