### PR TITLE
:Commentary! can only uncomment lines

### DIFF
--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -24,11 +24,6 @@ function! s:strip_white_space(l,r,line) abort
   return [l, r]
 endfunction
 
-function! s:excmd(force_uncomment, lnum1, lnum2)
-  let s:force_uncomment = a:force_uncomment
-  call s:go(a:lnum1, a:lnum2)
-endfunction
-
 function! s:go(...) abort
   if !a:0
     let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
@@ -41,7 +36,7 @@ function! s:go(...) abort
 
   let [l, r] = s:surroundings()
   let uncomment = 2
-  let force_uncomment = exists('s:force_uncomment') && s:force_uncomment
+  let force_uncomment = a:0 > 2 && a:3
   for lnum in range(lnum1,lnum2)
     let line = matchstr(getline(lnum),'\S.*\s\@<!')
     let [l, r] = s:strip_white_space(l,r,line)
@@ -83,7 +78,6 @@ function! s:go(...) abort
   finally
     let &modelines = modelines
   endtry
-  silent! unlet s:force_uncomment
   return ''
 endfunction
 
@@ -108,7 +102,7 @@ function! s:textobject(inner) abort
   endif
 endfunction
 
-command! -range -bar -bang Commentary call s:excmd(<bang>0,<line1>,<line2>)
+command! -range -bar -bang Commentary call s:go(<line1>,<line2>,<bang>0)
 xnoremap <expr>   <Plug>Commentary     <SID>go()
 nnoremap <expr>   <Plug>Commentary     <SID>go()
 nnoremap <expr>   <Plug>CommentaryLine <SID>go() . '_'

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -68,12 +68,10 @@ function! s:go(...) abort
       if line =~ '^\s*' . l
         let line = substitute(line,'\S.*\s\@<!','\=submatch(0)[strlen(l):-strlen(r)-1]','')
       endif
+    elseif uncomment
+      let line = substitute(line,'\S.*\s\@<!','\=submatch(0)[strlen(l):-strlen(r)-1]','')
     else
-      if uncomment
-        let line = substitute(line,'\S.*\s\@<!','\=submatch(0)[strlen(l):-strlen(r)-1]','')
-      else
-        let line = substitute(line,'^\%('.matchstr(getline(lnum1),indent).'\|\s*\)\zs.*\S\@<=','\=l.submatch(0).r','')
-      endif
+      let line = substitute(line,'^\%('.matchstr(getline(lnum1),indent).'\|\s*\)\zs.*\S\@<=','\=l.submatch(0).r','')
     endif
     call add(lines, line)
   endfor


### PR DESCRIPTION
Closes #120.

For the cases that you have some enclosing `if`, `try` or similar and you comment them out to run the code inside, but then you want to uncomment them, without commenting again the whole block. Right now if there's some uncommented line in the range, it will comment again the commented lines.