### PR TITLE
Use <leader> key instead of g

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,9 @@
 # commentary.vim
 
-Comment stuff out.  Use `gcc` to comment out a line (takes a count),
-`gc` to comment out the target of a motion (for example, `gcap` to
-comment out a paragraph), `gc` in visual mode to comment out the selection,
-and `gc` in operator pending mode to target a comment.  You can also use
+Comment stuff out.  Use `<leader>cc` to comment out a line (takes a count),
+`<leader>c` to comment out the target of a motion (for example, `<leader>cap` to
+comment out a paragraph), `<leader>c` in visual mode to comment out the selection,
+and `<leader>c` in operator pending mode to target a comment.  You can also use
 it as a command, either with a range like `:7,17Commentary`, or as part of a
 `:global` invocation like with `:g/TODO/Commentary`. That's it.
 
@@ -13,7 +13,7 @@ feature (I overlooked
 [tcomment.vim](https://github.com/tomtom/tcomment_vim)).  Striving for
 minimalism, it weighs in at under 100 lines of code.
 
-Oh, and it uncomments, too.  The above maps actually toggle, and `gcgc`
+Oh, and it uncomments, too.  The above maps actually toggle, and `<leader>c<leader>c`
 uncomments a set of adjacent commented lines.
 
 ## Installation

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# commentary.vim
+# commentary.vim forked from tpope/vim-commentary to use leader key instead of g
 
 Comment stuff out.  Use `gcc` to comment out a line (takes a count),
 `gc` to comment out the target of a motion (for example, `gcap` to

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# commentary.vim forked from tpope/vim-commentary to use leader key instead of g
+# commentary.vim
 
 Comment stuff out.  Use `gcc` to comment out a line (takes a count),
 `gc` to comment out the target of a motion (for example, `gcap` to

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -109,7 +109,7 @@ nnoremap <expr>   <Plug>CommentaryLine <SID>go() . '_'
 onoremap <silent> <Plug>Commentary        :<C-U>call <SID>textobject(get(v:, 'operator', '') ==# 'c')<CR>
 nnoremap <silent> <Plug>ChangeCommentary c:<C-U>call <SID>textobject(1)<CR>
 
-if !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
+if !hasmapto('<Plug>Commentary') || maparg('<leader>c','n') ==# ''
   xmap <leader>c  <Plug>Commentary
   nmap <leader>c  <Plug>Commentary
   omap <leader>c  <Plug>Commentary

--- a/plugin/commentary.vim
+++ b/plugin/commentary.vim
@@ -110,11 +110,11 @@ onoremap <silent> <Plug>Commentary        :<C-U>call <SID>textobject(get(v:, 'op
 nnoremap <silent> <Plug>ChangeCommentary c:<C-U>call <SID>textobject(1)<CR>
 
 if !hasmapto('<Plug>Commentary') || maparg('gc','n') ==# ''
-  xmap gc  <Plug>Commentary
-  nmap gc  <Plug>Commentary
-  omap gc  <Plug>Commentary
-  nmap gcc <Plug>CommentaryLine
-  nmap gcu <Plug>Commentary<Plug>Commentary
+  xmap <leader>c  <Plug>Commentary
+  nmap <leader>c  <Plug>Commentary
+  omap <leader>c  <Plug>Commentary
+  nmap <leader>cc <Plug>CommentaryLine
+  nmap <leader>cu <Plug>Commentary<Plug>Commentary
 endif
 
 nmap <silent> <Plug>CommentaryUndo :echoerr "Change your <Plug>CommentaryUndo map to <Plug>Commentary<Plug>Commentary"<CR>


### PR DESCRIPTION
It allows the user to puth whatever key instead of `g` as the prefix for the commands. See edea8f828cae5a2b7d9d990f1cfe2db8841d4797